### PR TITLE
Move beaker-in-the-box to RHEL7 base image

### DIFF
--- a/roles/beaker/data/distros/tasks/main.yml
+++ b/roles/beaker/data/distros/tasks/main.yml
@@ -14,7 +14,8 @@
 - name: import Fedora releases
   command: beaker-import --family=Fedora --arch=x86_64 {{ item }}
   with_items:
-    - http://download.fedoraproject.org/pub/fedora/linux/releases/27
+    - http://download.fedoraproject.org/pub/fedora/linux/releases/29
+    - http://download.fedoraproject.org/pub/fedora/linux/releases/30
 
 - name: import Fedora 28 tree
   command: beaker-import --family=Fedora {{ item }}

--- a/roles/serverlc/templates/beaker.ks.j2
+++ b/roles/serverlc/templates/beaker.ks.j2
@@ -1,10 +1,10 @@
-# Beaker is developed and tested on Red Hat Enterprise Linux 6, but any
+# Beaker is developed and tested on Red Hat Enterprise Linux 7, but any
 # compatible distro should work as well.
 url --url={{ netinstall_url }}
 {% for name, url in kickstart_repos.items() %}
 repo --name={{ name }} --baseurl={{ url }}
 {% endfor %}
-repo --name=beaker-server --baseurl=http://beaker-project.org/yum/server/RedHatEnterpriseLinux6/
+repo --name=beaker-server --baseurl=http://beaker-project.org/yum/server/RedHatEnterpriseLinux7/
 
 # The usual installation stuff. Beaker has no particular requirements here.
 auth --useshadow --enablemd5

--- a/setup_beaker.yml
+++ b/setup_beaker.yml
@@ -5,12 +5,12 @@
 
   vars:
     user_key: "{{ lookup('file', '{{ user_key_path }}') }}"
-    netinstall_url: http://mirror.centos.org/centos/6/os/x86_64
+    netinstall_url: http://mirror.centos.org/centos/7/os/x86_64/
     kickstart_repos:
-      install: http://mirror.centos.org/centos/6/os/x86_64/
-      updates: http://mirror.centos.org/centos/6/updates/x86_64/
-      extras: http://mirror.centos.org/centos/6/extras/x86_64/
-      cr: http://mirror.centos.org/centos/6/cr/x86_64/
+      install: http://mirror.centos.org/centos/7/os/x86_64/
+      updates: http://mirror.centos.org/centos/7/updates/x86_64/
+      extras: http://mirror.centos.org/centos/7/extras/x86_64/
+      cr: http://mirror.centos.org/centos/7/cr/x86_64/
     user_distros: []
   vars_files:
     - beaker_vars.yml

--- a/setup_sandbox.yml
+++ b/setup_sandbox.yml
@@ -8,13 +8,13 @@
 
   vars:
     user_key: "{{ lookup('file', '{{ user_key_path }}') }}"
-    netinstall_url: http://mirror.centos.org/centos/6/os/x86_64
+    netinstall_url: http://mirror.centos.org/centos/7/os/x86_64
     kickstart_repos:
-      install: http://mirror.centos.org/centos/6/os/x86_64/
-      updates: http://mirror.centos.org/centos/6/updates/x86_64/
-      extras: http://mirror.centos.org/centos/6/extras/x86_64/
-      cr: http://mirror.centos.org/centos/6/cr/x86_64/
-      beakerclient: http://beaker-project.org/yum/client/CentOS6
+      install: http://mirror.centos.org/centos/7/os/x86_64/
+      updates: http://mirror.centos.org/centos/7/updates/x86_64/
+      extras: http://mirror.centos.org/centos/7/extras/x86_64/
+      cr: http://mirror.centos.org/centos/7/cr/x86_64/
+      beakerclient: http://beaker-project.org/yum/client/CentOS7
     user_distros: []
   vars_files:
     - sandbox_vars.yml


### PR DESCRIPTION
Beaker 27 is no longer working on RHEL 6.
Beaker-in-the-box should be updated also to RHEL 7 to support our development.
Signed-off-by: Martin Styk <mastyk@redhat.com>