### PR TITLE
Start Beaker Libvirt Network by default

### DIFF
--- a/beaker_vars.yml
+++ b/beaker_vars.yml
@@ -3,6 +3,7 @@ network:
   name: beaker
   forward: nat
   mac: '52:54:00:6B:11:87'
+  autostart: yes
   hosts:
     - {mac: '52:54:00:c6:73:4f', name: 'beaker-server-lc.beaker', ip: '192.168.120.104'}
     - {mac: '52:54:00:c6:71:8e', name: 'beaker-test-vm1.beaker', ip: '192.168.120.105'}

--- a/roles/libvirt/tasks/main.yml
+++ b/roles/libvirt/tasks/main.yml
@@ -27,6 +27,7 @@
   virt_net:
     state: active
     name: "{{ network.name }}"
+    autostart: "{{ network.autostart }}"
 
 - name: gather facts about storage pools
   virt_pool:


### PR DESCRIPTION
Start Beaker network by default.
Users can opt-out if they want to.

Signed-off-by: Martin Styk <mastyk@redhat.com>