### PR TITLE
Update Fedora distros

### DIFF
--- a/roles/beaker/data/distros/tasks/main.yml
+++ b/roles/beaker/data/distros/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: import user defined distros
   command: beaker-import {{ item }}
   with_items: "{{ user_distros }}"
+  ignore_errors: yes
 
 - name: import centos
   command: beaker-import {{ item }}
@@ -10,12 +11,14 @@
     - http://mirror.centos.org/centos/6/os/x86_64/
     - http://mirror.centos.org/centos/6/os/i386/
     - http://mirror.centos.org/centos/7/os/x86_64/
+  ignore_errors: yes
 
 - name: import Fedora releases
   command: beaker-import --family=Fedora --arch=x86_64 {{ item }}
   with_items:
-    - http://download.fedoraproject.org/pub/fedora/linux/releases/29
+    - http://download.fedoraproject.org/pub/fedora/linux/releases/31
     - http://download.fedoraproject.org/pub/fedora/linux/releases/30
+  ignore_errors: yes
 
 - name: run beaker-repo-update
   command: beaker-repo-update

--- a/roles/beaker/data/distros/tasks/main.yml
+++ b/roles/beaker/data/distros/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: import Fedora releases
   command: beaker-import --family=Fedora --arch=x86_64 {{ item }}
   with_items:
-    - http://download.fedoraproject.org/pub/fedora/linux/releases/31
     - http://download.fedoraproject.org/pub/fedora/linux/releases/30
+    - http://download.fedoraproject.org/pub/fedora/linux/releases/31
   ignore_errors: yes
 
 - name: run beaker-repo-update


### PR DESCRIPTION
Remove Fedora 29 and add Fedora 31.

Allow the distro import to fail, as it's not required to complete the
beaker setup.

Fixes #16