### PR TITLE
Add wrapper package for MariaDB when using SCL

### DIFF
--- a/roles/beaker/setup/database/tasks/main.yml
+++ b/roles/beaker/setup/database/tasks/main.yml
@@ -37,6 +37,12 @@
     state: present
   when: is_scl_server
 
+- name: install system-wide wrapper for RH-MariaDB
+  package:
+    name: rh-mariadb102-mariadb-syspaths
+    state: present
+  when: is_scl_server
+
 - name: copy MariaDB config
   copy:
     src: my.cnf


### PR DESCRIPTION
Without this package, user is forced to use SCL context when playing with DB.
This is quite unpractical.

With this package, we can execute command like `mysql` right away.

Signed-off-by: Martin Styk <mastyk@redhat.com>